### PR TITLE
Include product description in opportunity message

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -77,7 +77,7 @@ def opp_url(opp):
     return 'http://{0}/learn-barcode/{1}'.format(local_ip(), opp['opp_id'])
 
 
-def create_barcode_opp(trello_db, barcode, desc):
+def create_barcode_opp(trello_db, barcode, desc=''):
     """Creates a learning opportunity for the given barcode and writes it to Trello.
     
        Returns the dict."""

--- a/scan.py
+++ b/scan.py
@@ -77,7 +77,7 @@ def opp_url(opp):
     return 'http://{0}/learn-barcode/{1}'.format(local_ip(), opp['opp_id'])
 
 
-def create_barcode_opp(trello_db, barcode):
+def create_barcode_opp(trello_db, barcode, desc):
     """Creates a learning opportunity for the given barcode and writes it to Trello.
     
        Returns the dict."""
@@ -85,6 +85,7 @@ def create_barcode_opp(trello_db, barcode):
         'type': 'barcode',
         'opp_id': generate_opp_id(),
         'barcode': barcode,
+        'desc': desc,
         'created_dt': datetime.now().strftime('%Y-%m-%d %H:%M:%S')
     }
 
@@ -93,7 +94,7 @@ def create_barcode_opp(trello_db, barcode):
 
 
 def publish_barcode_opp(opp):
-    message = '''Hi! Oscar here. You scanned a code I didn't recognize. Care to fill me in?  {0}'''.format(opp_url(opp))
+    message = '''Hi! Oscar here. You scanned a code I didn't recognize for a "{1}". Care to fill me in?  {0}'''.format(opp_url(opp), opp['desc'])
     subject = '''Didn't Recognize Barcode'''
     communication_method = conf.get()['communication_method']
     if communication_method == 'email':
@@ -205,7 +206,7 @@ while True:
     except urllib2.HTTPError, e:
         if 'UPC/EAN code invalid' in e.msg:
             print "Barcode {0} not recognized as a UPC; creating learning opportunity".format(repr(barcode))
-            opp = create_barcode_opp(trello_db, barcode)
+            opp = create_barcode_opp(trello_db, barcode, desc)
             print "Publishing learning opportunity"
             publish_barcode_opp(opp)
             continue

--- a/scan.py
+++ b/scan.py
@@ -206,13 +206,19 @@ while True:
     except urllib2.HTTPError, e:
         if 'UPC/EAN code invalid' in e.msg:
             print "Barcode {0} not recognized as a UPC; creating learning opportunity".format(repr(barcode))
-            opp = create_barcode_opp(trello_db, barcode, desc)
+            try:
+                opp = create_barcode_opp(trello_db, barcode, desc)
+            except:
+                opp = create_barcode_opp(trello_db, barcode)
             print "Publishing learning opportunity"
             publish_barcode_opp(opp)
             continue
         elif 'Not found' in e.msg:
             print "Barcode {0} not found in UPC database; creating learning opportunity".format(repr(barcode))
-            opp = create_barcode_opp(trello_db, barcode)
+            try:
+                opp = create_barcode_opp(trello_db, barcode, desc)
+            except:
+                opp = create_barcode_opp(trello_db, barcode)
             print "Publishing learning opportunity via SMS"
             publish_barcode_opp(opp)
             continue


### PR DESCRIPTION
Take Digit Eyes description and provide it in the message so you know what product the barcode was for and don't have to remember what item was scanned or be there when it was scanned to teach it (if a family member other then yourself scanned it). 

Example message (from my own testing):
Hi! Oscar here. You scanned a code I didn't recognize for a "Energizer Max Batteries Alkaline, 9V". Care to fill me in?  http://192.168.1.105/learn-barcode/LIc8ZRnezNg4

Then you associate it with "9V batteries" since there is no reason to be brand specific, you just need to get the correct batteries, whatever is cheapest or available.