### PR TITLE
Add support for Openfoodfacts.org

### DIFF
--- a/install.py
+++ b/install.py
@@ -38,6 +38,8 @@ print
 print "and sign up for an account there. This is the database that Oscar uses to"
 print "match barcodes with names of products. When you're ready, enter your"
 print "API credentials. They can be found on the \"My Account\" page."
+print 
+print "Want to use openfoodfacts.org? Customise /etc/oscar.yaml to set the barcode_api to 'openfoodfacts'"
 print
 digiteyes_app_key = raw_input('App Key ("K" Code): ')
 digiteyes_auth_key = raw_input('Authorization Key ("M" Code): ')

--- a/install.py
+++ b/install.py
@@ -276,7 +276,7 @@ trello_db_board: '{trello_db_board}'
 digiteyes_app_key: '{digiteyes_app_key}'
 digiteyes_auth_key: '{digiteyes_auth_key}'
 
-# possible values: 'digiteyes' or 'zeroapi'
+# possible values: 'digiteyes', 'openfoodfacts' or 'zeroapi'
 barcode_api: digiteyes
 '''.format(**locals()))
 oscar_yaml.close()

--- a/scan.py
+++ b/scan.py
@@ -84,7 +84,11 @@ class OpenFoodFactsAPI:
             if data['status_verbose'] != 'product found':
               raise CodeNotFound(data['status_verbose'])
 
-            return data['generic_name_en']
+            if 'product_name' in data['product']:
+              return data['product']['product_name']
+
+            if 'generic_name_en' in data['product']:
+              return data['product']['generic_name_en']
         except urllib2.HTTPError, e:
             if 'Not found' in e.msg:
                 raise CodeNotFound(e.msg)

--- a/scan.py
+++ b/scan.py
@@ -81,7 +81,7 @@ class OpenFoodFactsAPI:
             json_blob = urllib2.urlopen(url).read()
             data = json.loads(json_blob)
 
-            if data['status_version'] != 'product found'
+            if data['status_version'] != 'product found':
               raise CodeNotFound(data['status_version'])
 
             return data['generic_name_en']
@@ -253,7 +253,7 @@ while True:
     barcode_api = conf.get()['barcode_api']
     if barcode_api == 'zeroapi':
         u = FakeAPI()
-    else if barcode_api == 'openfoodfacts':
+    elif barcode_api == 'openfoodfacts':
         u = OpenFoodFactsAPI()
     else:
         u = UPCAPI(conf.get()['digiteyes_app_key'], conf.get()['digiteyes_auth_key'])

--- a/scan.py
+++ b/scan.py
@@ -71,6 +71,26 @@ class UPCAPI:
             else:
                 raise
 
+class OpenFoodFactsAPI:
+    def get_description(self, upc):
+        """Returns the product description for the given UPC.
+
+           `upc`: A string containing the UPC."""
+        url = 'http://world.openfoodfacts.org/api/v0/product/{0}.json'.format(upc)
+        try:
+            json_blob = urllib2.urlopen(url).read()
+            data = json.loads(json_blob)
+
+            if data['status_version'] != 'product found'
+              raise CodeNotFound(data['status_version'])
+
+            return data['generic_name_en']
+        except urllib2.HTTPError, e:
+            if 'Not found' in e.msg:
+                raise CodeNotFound(e.msg)
+            else:
+                raise
+
 
 class FakeAPI:
     def get_description(self, upc):
@@ -114,6 +134,9 @@ def create_barcode_opp(trello_db, barcode, desc=''):
 def publish_barcode_opp(opp):
     message = '''Hi! Oscar here. You scanned a code I didn't recognize for a "{1}". Care to fill me in?  {0}'''.format(opp_url(opp), opp['desc'])
     subject = '''Didn't Recognize Barcode'''
+    if conf.get()['barcode_api'] == 'openfoodfacts':
+      message = '''Hi! Oscar here. You scanned a code I didn't recognize for a "{1}". Care to fill me in?  {0}. Add to http://world.openfoodfacts.org/cgi/product.pl ?'''.format(opp_url(opp), opp['desc'])
+    
     communication_method = conf.get()['communication_method']
     if communication_method == 'email':
         send_via_email(message, subject)
@@ -227,8 +250,11 @@ while True:
         continue
 
     # Get the item's description
-    if conf.get()['barcode_api'] == 'zeroapi':
+    barcode_api = conf.get()['barcode_api']
+    if barcode_api == 'zeroapi':
         u = FakeAPI()
+    else if barcode_api == 'openfoodfacts':
+        u = OpenFoodFactsAPI()
     else:
         u = UPCAPI(conf.get()['digiteyes_app_key'], conf.get()['digiteyes_auth_key'])
     try:

--- a/scan.py
+++ b/scan.py
@@ -81,8 +81,8 @@ class OpenFoodFactsAPI:
             json_blob = urllib2.urlopen(url).read()
             data = json.loads(json_blob)
 
-            if data['status_version'] != 'product found':
-              raise CodeNotFound(data['status_version'])
+            if data['status_verbose'] != 'product found':
+              raise CodeNotFound(data['status_verbose'])
 
             return data['generic_name_en']
         except urllib2.HTTPError, e:


### PR DESCRIPTION
#25

This might be worth changing to be the default instead of digit-eyes - while it will mean less coverage in the short term, there are no API keys and setup is a lot easier.

Combined with their android app; adding detailed new food items is pretty easy.

It also gives back a lot of structured data around the barcode; so we can lean on it's categories to determine if something is a kind of Milk; rather than rules for example.

Leaving this open for discussion, will merge in a few days.
